### PR TITLE
add option to define installation location with $GR1C_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ CORE_PROGRAMS = gr1c rg
 EXP_PROGRAMS = grpatch
 AUX_PROGRAMS = autman
 
-
-prefix = /usr/local
-exec_prefix = $(prefix)
-bindir = $(exec_prefix)/bin
+ifdef GR1C_PREFIX
+  bindir = $(GR1C_PREFIX)
+else
+  prefix = /usr/local
+  exec_prefix = $(prefix)
+  bindir = $(exec_prefix)/bin
+endif
 
 # Possibly change to `cp' when `install' is unavailable
 INSTALL = install

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -126,10 +126,10 @@ administrative privileges, one solution is
 
 which will copy `gr1c` and `rg` to `/usr/local/bin`, a commonly used location
 for "local" installations.  This is based on a default installation prefix of
-`/usr/local`.  Adjust it by invoking `make` with something like
-`prefix=/your/new/path`.  The programs `grpatch` and `grjit` are *not* included
-in as an effect of `make install`.  [Extra instructions](#extras) concerning
-these are below.
+`/usr/local`.  Adjust it to the desired path by setting the environment variable
+`GR1C_PREFIX` before invoking `make`. For example `export GR1C_PREFIX=~/local` will
+install to `~/local/bin`. The programs `grpatch` and `grjit` are *not* included in as
+an effect of `make install`. [Extra instructions](#extras) concerning these are below.
 
 
 <h2 id="extras">Extras</h2>


### PR DESCRIPTION
This is convenient for automatic installation scripts like [this one](https://github.com/tulip-control/tulip-control/blob/ubuntu/contrib/nessainstall/install.sh#L264) used for `tulip`.
